### PR TITLE
Diabetic Retinopathy #7

### DIFF
--- a/src/eye_extractor/common/severity.py
+++ b/src/eye_extractor/common/severity.py
@@ -12,28 +12,8 @@ class Severity(enum.IntEnum):
     MILD = 5
     MODERATE = 6
     SEVERE = 7
+    VERY_SEVERE = 8
 
-
-MILD_PAT = re.compile(
-    r'\b('
-    r'mild'
-    r')\b',
-    re.I
-)
-
-MODERATE_PAT = re.compile(
-    r'\b('
-    r'moderate'
-    r')\b',
-    re.I
-)
-
-SEVERE_PAT = re.compile(
-    r'\b('
-    r'severe'
-    r')\b',
-    re.I
-)
 
 SEVERITY_PAT = re.compile(
     r'\b('
@@ -41,36 +21,57 @@ SEVERITY_PAT = re.compile(
     r')\b',
     re.I
 )
-
 Q1_PAT = re.compile(
     r'\b('
     r'\w+\s+quadrant'
     r')\b',
     re.I
 )
-
 Q2_PAT = re.compile(
     r'\b('
     r'\w+(\s+and|,)\s+\w+\s+quadrant(s)?'
     r')\b',
     re.I
 )
-
 Q3_PAT = re.compile(
     r'\b('
     r'\w+\s*,\s+\w+(\s+and|,)\s+\w+\s+quadrant(s)?'
     r')\b',
     re.I
 )
-
 Q4_PAT = re.compile(
     r'\b('
     r'all(\s+4)?\s+quadrant(s)?'
     r')\b',
     re.I
 )
+MILD_PAT = re.compile(
+    r'\b('
+    r'mild'
+    r')\b',
+    re.I
+)
+MODERATE_PAT = re.compile(
+    r'\b('
+    r'moderate'
+    r')\b',
+    re.I
+)
+SEVERE_PAT = re.compile(
+    r'\b('
+    r'(?<!very\s)severe'  # Negative lookbehind cannot contain a quantifier.
+    r')\b',
+    re.I
+)
+VERY_SEVERE_PAT = re.compile(
+    r'\b('
+    r'very\s+severe'
+    r')\b',
+    re.I
+)
 
 SEVERITY_PATS = [
+    (VERY_SEVERE_PAT, Severity.VERY_SEVERE),
     (SEVERE_PAT, Severity.SEVERE),
     (MODERATE_PAT, Severity.MODERATE),
     (MILD_PAT, Severity.MILD),

--- a/src/eye_extractor/common/severity.py
+++ b/src/eye_extractor/common/severity.py
@@ -2,6 +2,43 @@ import enum
 import re
 
 
+class Risk(enum.IntEnum):
+    UNKNOWN = -1
+    NONE = 0
+    LOW_RISK = 1
+    HIGH_RISK = 2
+    YES_NOS = 3
+
+
+LOW_RISK_PAT = re.compile(
+    r'\b('
+    r'low\s+risk'
+    r')\b',
+    re.I
+)
+HIGH_RISK_PAT = re.compile(
+    r'\b('
+    r'high\s+risk'
+    r')\b',
+    re.I
+)
+
+RISK_PATS = [
+    (HIGH_RISK_PAT, Risk.HIGH_RISK),
+    (LOW_RISK_PAT, Risk.LOW_RISK),
+]
+
+
+def extract_risk(text: str) -> list[Risk]:
+    risks = []
+
+    for pat, risk in RISK_PATS:
+        for _ in pat.finditer(text):
+            risks.append(risk)
+
+    return risks
+
+
 class Severity(enum.IntEnum):
     UNKNOWN = -1
     NONE = 0

--- a/src/eye_extractor/common/severity.py
+++ b/src/eye_extractor/common/severity.py
@@ -13,6 +13,7 @@ class Severity(enum.IntEnum):
     MODERATE = 6
     SEVERE = 7
     VERY_SEVERE = 8
+    NOS = 9
 
 
 SEVERITY_PAT = re.compile(

--- a/src/eye_extractor/common/severity.py
+++ b/src/eye_extractor/common/severity.py
@@ -13,7 +13,7 @@ class Severity(enum.IntEnum):
     MODERATE = 6
     SEVERE = 7
     VERY_SEVERE = 8
-    NOS = 9
+    YES_NOS = 9
 
 
 SEVERITY_PAT = re.compile(

--- a/src/eye_extractor/dr/cmt_value.py
+++ b/src/eye_extractor/dr/cmt_value.py
@@ -3,14 +3,6 @@ import re
 from eye_extractor.nlp.negate.negation import is_negated
 from eye_extractor.laterality import build_laterality_table, create_new_variable, Laterality, LateralityLocator
 
-# Old pattern, too greedy.
-# CMT_VALUE_PAT = re.compile(
-#     r'\b('
-#     r'(?:OD\W*|OS\W*|CMT\s*|central macular thickness[ :]*)(?P<digit>\d{3,4})(?!/|\.|\W*mmhg)(um)?'
-#     r')\b',
-#     re.I
-# )
-
 CMT_VALUE_OD_OS_UNK_PAT = re.compile(
     r'\b('
     r'(CMT|central macular thickness:?)\s+'
@@ -20,7 +12,6 @@ CMT_VALUE_OD_OS_UNK_PAT = re.compile(
     r')\b',
     re.I
 )
-
 CMT_VALUE_OD_SEP_OS_PAT = re.compile(
     r'\b('
     r'(CMT|central macular thickness:?)\s+'
@@ -71,6 +62,7 @@ def _create_new_cmt_var(text: str,
                                    'regex': pat_label,
                                    'source': source,
                                },
+                               # If `known_laterality == Laterality.UNKNOWN`, laterality will be searched for.
                                known_laterality=match2lat[match_name])
 
 

--- a/src/eye_extractor/dr/cmt_value.py
+++ b/src/eye_extractor/dr/cmt_value.py
@@ -1,10 +1,23 @@
 import re
 
 from eye_extractor.nlp.negate.negation import is_negated
-from eye_extractor.laterality import build_laterality_table, create_new_variable
+from eye_extractor.laterality import build_laterality_table, create_new_variable, Laterality
+
+# Old pattern, too greedy.
+# CMT_VALUE_PAT = re.compile(
+#     r'\b('
+#     r'(?:OD\W*|OS\W*|CMT\s*|central macular thickness[ :]*)(?P<digit>\d{3,4})(?!/|\.|\W*mmhg)(um)?'
+#     r')\b',
+#     re.I
+# )
 
 CMT_VALUE_PAT = re.compile(
-    r'\b(?:OD\W*|OS\W*|CMT\s*|central macular thickness[ :]*)(?P<digit>\d{2,3})(?!/|\.|\W*mmhg)(um)?\b',
+    r'\b('
+    r'(CMT|central macular thickness:?)\s+'
+    r'(OD:?\s*(?P<od_value>\d{3}))?\s?'
+    r'(OS:?\s*(?P<os_value>\d{3}))?'
+    r'(?P<unk_value>\d{3})?'
+    r')\b',
     re.I
 )
 
@@ -22,13 +35,40 @@ def get_cmt_value(text: str, *, headers=None, lateralities=None) -> list:
 
 
 def _get_cmt_value(text: str, lateralities, source: str) -> dict:
-    for m in CMT_VALUE_PAT.finditer(text):
-        negated = is_negated(m, text, word_window=1)
-        yield create_new_variable(text, m, lateralities, 'dmacedema_cmt', {
-            'value': 0 if negated else int(m.group('digit')),
-            'term': m.group(),
-            'label': f'No CMT value' if negated else 'CMT value',
-            'negated': negated,
-            'regex': 'CMT_VALUE_PAT',
-            'source': source,
-        })
+    for match in CMT_VALUE_PAT.finditer(text):
+        negated = is_negated(match, text, word_window=1)
+        # CMT_VALUE_PAT will match to text without values, like 'CMT '.
+        # Create new variable only if a value is captured.
+        if match['od_value']:
+            yield create_new_variable(text, match, lateralities, 'dmacedema_cmt',
+                                      {
+                                          'value': 0 if negated else int(match['od_value']),
+                                          'term': match.group(),
+                                          'label': f'No CMT value' if negated else 'CMT value',
+                                          'negated': negated,
+                                          'regex': 'CMT_VALUE_PAT',
+                                          'source': source,
+                                      },
+                                      known_laterality=Laterality.OD)
+        if match['os_value']:
+            yield create_new_variable(text, match, lateralities, 'dmacedema_cmt',
+                                      {
+                                          'value': 0 if negated else int(match['os_value']),
+                                          'term': match.group(),
+                                          'label': f'No CMT value' if negated else 'CMT value',
+                                          'negated': negated,
+                                          'regex': 'CMT_VALUE_PAT',
+                                          'source': source,
+                                      },
+                                      known_laterality=Laterality.OS)
+        if match['unk_value']:
+            yield create_new_variable(text, match, lateralities, 'dmacedema_cmt',
+                                      {
+                                          'value': 0 if negated else int(match['unk_value']),
+                                          'term': match.group(),
+                                          'label': f'No CMT value' if negated else 'CMT value',
+                                          'negated': negated,
+                                          'regex': 'CMT_VALUE_PAT',
+                                          'source': source,
+                                      },
+                                      known_laterality=Laterality.UNKNOWN)

--- a/src/eye_extractor/dr/diabetic_retinopathy.py
+++ b/src/eye_extractor/dr/diabetic_retinopathy.py
@@ -1,7 +1,7 @@
 from eye_extractor.dr.binary_vars import get_dr_binary
 from eye_extractor.dr.cmt_value import get_cmt_value
 from eye_extractor.dr.cws import get_cottonwspot
-from eye_extractor.dr.dr_type import get_dr_type
+from eye_extractor.dr.dr_type import get_dr_type, get_pdr
 from eye_extractor.dr.exudates import get_exudates
 from eye_extractor.dr.hemorrhage_type import get_hemorrhage_type
 from eye_extractor.dr.irma import get_irma
@@ -21,5 +21,6 @@ def extract_dr_variables(text: str, *, headers=None, lateralities=None) -> dict:
         'irma': get_irma(text, headers=headers, lateralities=lateralities),
         'laser_scar_type': get_laser_scar_type(text, headers=headers, lateralities=lateralities),
         'nv_types': get_nv_types(text, headers=headers, lateralities=lateralities),
+        'pdr': get_pdr(text, headers=headers, lateralities=lateralities),
         'venous_beading': get_ven_beading(text, headers=headers, lateralities=lateralities),
     }

--- a/src/eye_extractor/dr/dr_type.py
+++ b/src/eye_extractor/dr/dr_type.py
@@ -35,8 +35,6 @@ DR_PAT = re.compile(
 )
 
 
-# TODO: Add 'VERY_SEVERE' to NPDR.
-# TODO: Decouple PDR and create new severity categories: unspecified, no, low risk, high risk.
 def get_dr_type(text: str, *, headers=None, lateralities=None) -> list:
     if not lateralities:
         lateralities = build_laterality_table(text)

--- a/src/eye_extractor/dr/dr_type.py
+++ b/src/eye_extractor/dr/dr_type.py
@@ -87,6 +87,15 @@ def _get_dr_type(text: str, lateralities, source: str) -> dict:
                         'regex': pat_label,
                         'source': source,
                     })
+                else:  # Affirmative without severity quantifier.
+                    yield create_new_variable(text, m, lateralities, sev_var, {
+                        'value': Severity.NOS,
+                        'term': m.group(),
+                        'label': dr_label,
+                        'negated': negated,
+                        'regex': pat_label,
+                        'source': source,
+                    })
                 yield create_new_variable(text, m, lateralities, 'diabretinop_type', {
                     'value': DrType.NONE if negated else dr_type,
                     'term': m.group(),

--- a/src/eye_extractor/dr/dr_type.py
+++ b/src/eye_extractor/dr/dr_type.py
@@ -89,7 +89,7 @@ def _get_dr_type(text: str, lateralities, source: str) -> dict:
                     })
                 else:  # Affirmative without severity quantifier.
                     yield create_new_variable(text, m, lateralities, sev_var, {
-                        'value': Severity.NOS,
+                        'value': Severity.YES_NOS,
                         'term': m.group(),
                         'label': dr_label,
                         'negated': negated,

--- a/src/eye_extractor/dr/hemorrhage_type.py
+++ b/src/eye_extractor/dr/hemorrhage_type.py
@@ -86,8 +86,8 @@ def _get_hemorrhage_type(text: str, lateralities, source: str) -> dict:
                           boundary_chars='',
                           word_window=5):
                 break
-            # Severity found & positive instance.
             if sev_var:
+                # Severity found & positive instance.
                 if severities:
                     for sev in severities:
                         yield create_new_variable(text, m, lateralities, sev_var, {
@@ -108,7 +108,8 @@ def _get_hemorrhage_type(text: str, lateralities, source: str) -> dict:
                         'regex': f'{hem_label.upper()}_PAT',
                         'source': source,
                     })
-                else:  # Affirmative without severity quantifier.
+                # Affirmative without severity quantifier.
+                else:
                     yield create_new_variable(text, m, lateralities, sev_var, {
                         'value': Severity.YES_NOS,
                         'term': m.group(),

--- a/src/eye_extractor/dr/hemorrhage_type.py
+++ b/src/eye_extractor/dr/hemorrhage_type.py
@@ -87,26 +87,36 @@ def _get_hemorrhage_type(text: str, lateralities, source: str) -> dict:
                           word_window=5):
                 break
             # Severity found & positive instance.
-            if sev_var and severities:
-                for sev in severities:
+            if sev_var:
+                if severities:
+                    for sev in severities:
+                        yield create_new_variable(text, m, lateralities, sev_var, {
+                            'value': sev,
+                            'term': m.group(),
+                            'label': f'{hem_label} hemorrhage',
+                            'negated': negated,
+                            'regex': f'{hem_label.upper()}_PAT',
+                            'source': source,
+                        })
+                # Severity found & negative instance.
+                elif negated:
                     yield create_new_variable(text, m, lateralities, sev_var, {
-                        'value': sev,
+                        'value': Severity.NONE,
+                        'term': m.group(),
+                        'label': f'No {hem_label} hemorrhage',
+                        'negated': negated,
+                        'regex': f'{hem_label.upper()}_PAT',
+                        'source': source,
+                    })
+                else:  # Affirmative without severity quantifier.
+                    yield create_new_variable(text, m, lateralities, sev_var, {
+                        'value': Severity.NOS,
                         'term': m.group(),
                         'label': f'{hem_label} hemorrhage',
                         'negated': negated,
                         'regex': f'{hem_label.upper()}_PAT',
                         'source': source,
                     })
-            # Severity found & negative instance.
-            elif negated:
-                yield create_new_variable(text, m, lateralities, sev_var, {
-                    'value': Severity.NONE,
-                    'term': m.group(),
-                    'label': f'No {hem_label} hemorrhage',
-                    'negated': negated,
-                    'regex': f'{hem_label.upper()}_PAT',
-                    'source': source,
-                })
             # Severity not found, both positive and negative instance.
             yield create_new_variable(text, m, lateralities, 'hemorrhage_typ_dr', {
                 'value': HemorrhageType.NONE if negated else hem_type,

--- a/src/eye_extractor/dr/hemorrhage_type.py
+++ b/src/eye_extractor/dr/hemorrhage_type.py
@@ -110,7 +110,7 @@ def _get_hemorrhage_type(text: str, lateralities, source: str) -> dict:
                     })
                 else:  # Affirmative without severity quantifier.
                     yield create_new_variable(text, m, lateralities, sev_var, {
-                        'value': Severity.NOS,
+                        'value': Severity.YES_NOS,
                         'term': m.group(),
                         'label': f'{hem_label} hemorrhage',
                         'negated': negated,

--- a/src/eye_extractor/dr/irma.py
+++ b/src/eye_extractor/dr/irma.py
@@ -58,7 +58,7 @@ def _get_irma(text: str, lateralities, source: str) -> dict:
             })
         else:  # Affirmative without severity quantifier.
             yield create_new_variable(text, m, lateralities, 'irma', {
-                'value': Severity.MILD,
+                'value': Severity.NOS,
                 'term': m.group(),
                 'label': 'IRMA',
                 'negated': negated,

--- a/src/eye_extractor/dr/irma.py
+++ b/src/eye_extractor/dr/irma.py
@@ -58,7 +58,7 @@ def _get_irma(text: str, lateralities, source: str) -> dict:
             })
         else:  # Affirmative without severity quantifier.
             yield create_new_variable(text, m, lateralities, 'irma', {
-                'value': Severity.NOS,
+                'value': Severity.YES_NOS,
                 'term': m.group(),
                 'label': 'IRMA',
                 'negated': negated,

--- a/src/eye_extractor/dr/venous_beading.py
+++ b/src/eye_extractor/dr/venous_beading.py
@@ -51,7 +51,7 @@ def _get_ven_beading(text: str, lateralities, source: str) -> dict:
                 })
         else:  # Without severity quantifier.
             yield create_new_variable(text, m, lateralities, 'venbeading', {
-                'value': Severity.NONE if negated else Severity.MILD,
+                'value': Severity.NONE if negated else Severity.NOS,
                 'term': m.group(),
                 'label': f'{"No v" if negated else "V"}enous beading',
                 'negated': negated,

--- a/src/eye_extractor/dr/venous_beading.py
+++ b/src/eye_extractor/dr/venous_beading.py
@@ -51,7 +51,7 @@ def _get_ven_beading(text: str, lateralities, source: str) -> dict:
                 })
         else:  # Without severity quantifier.
             yield create_new_variable(text, m, lateralities, 'venbeading', {
-                'value': Severity.NONE if negated else Severity.NOS,
+                'value': Severity.NONE if negated else Severity.YES_NOS,
                 'term': m.group(),
                 'label': f'{"No v" if negated else "V"}enous beading',
                 'negated': negated,

--- a/src/eye_extractor/output/amd.py
+++ b/src/eye_extractor/output/amd.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from eye_extractor.amd.amd import AMD
 from eye_extractor.amd.cnv import ChoroidalNeoVasc
 from eye_extractor.amd.dry import DrySeverity
@@ -69,9 +71,9 @@ def build_amd(data, *, is_amd=None, lat=Laterality.UNKNOWN, note_date=None, macu
     wnl_lat = macula_is_wnl(macula_wnl, note_date)
     if wnl_lat == Laterality.OU:
         return {
-            'amd_re': AMD.NO,
-            'amd_le': AMD.NO,
-            'amd_unk': AMD.NO,
+            'amd_re': AMD.NO.value,
+            'amd_le': AMD.NO.value,
+            'amd_unk': AMD.NO.value,
         }
     results = {
         'amd_re': AMD.UNKNOWN,
@@ -91,6 +93,7 @@ def build_amd(data, *, is_amd=None, lat=Laterality.UNKNOWN, note_date=None, macu
         results['amd_re'] = AMD.NO
     if wnl_lat == Laterality.OS:
         results['amd_le'] = AMD.NO
+    results = {key: (val.value if isinstance(val, Enum) else val) for key, val in results.items()}
     return results
 
 

--- a/src/eye_extractor/output/columns.py
+++ b/src/eye_extractor/output/columns.py
@@ -3,7 +3,7 @@ from eye_extractor.amd.scar import Scar
 from eye_extractor.amd.wet import WetSeverity
 from eye_extractor.common.algo.fluid import Fluid
 from eye_extractor.common.algo.treatment import Treatment
-from eye_extractor.common.severity import Severity
+from eye_extractor.common.severity import Risk, Severity
 from eye_extractor.exam.gonio import Gonio
 from eye_extractor.glaucoma.dx import GlaucomaType
 from eye_extractor.glaucoma.preglaucoma import Preglaucoma
@@ -464,9 +464,9 @@ OUTPUT_COLUMNS = {
     'nonprolifdr_le': [is_string_in_enum(Severity)],
     'nonprolifdr_unk': [is_string_in_enum(Severity)],
     # Proliferative DR severity
-    'prolifdr_re': [is_string_in_enum(Severity)],
-    'prolifdr_le': [is_string_in_enum(Severity)],
-    'prolifdr_unk': [is_string_in_enum(Severity)],
+    'prolifdr_re': [is_string_in_enum(Risk)],
+    'prolifdr_le': [is_string_in_enum(Risk)],
+    'prolifdr_unk': [is_string_in_enum(Risk)],
     # Intraretinal hemorrhage severity
     'intraretinal_hem_re': [is_string_in_enum(Severity)],
     'intraretinal_hem_le': [is_string_in_enum(Severity)],

--- a/src/eye_extractor/output/dr.py
+++ b/src/eye_extractor/output/dr.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 from eye_extractor.common.algo.fluid import Fluid, fluid_prioritization, rename_fluid
 from eye_extractor.common.algo.treatment import Treatment
 from eye_extractor.common.drug.antivegf import AntiVegf, rename_antivegf
-from eye_extractor.common.severity import Severity
+from eye_extractor.common.severity import Risk, Severity
 from eye_extractor.dr.dr_type import DrType
 from eye_extractor.dr.hemorrhage_type import HemorrhageType
 from eye_extractor.output.common import macula_is_wnl
@@ -156,10 +156,10 @@ def build_npdr_severity(data, *, note_date=None):
 
 def build_pdr_severity(data, *, note_date=None):
     return column_from_variable_abbr(
-        'prolifdr', Severity.UNKNOWN, data,
+        'prolifdr', Risk.UNKNOWN, data,
         restrict_date=note_date,
         enum_to_str=True,
-        transformer_func=Severity,
+        transformer_func=Risk,
     )
 
 
@@ -285,7 +285,7 @@ def build_dr_variables(data):
     results.update(build_nve(curr['nv_types'], note_date=note['date']))
     results.update(build_dr_type(curr['dr_type'], note_date=note['date']))
     results.update(build_npdr_severity(curr['dr_type'], note_date=note['date']))
-    results.update(build_pdr_severity(curr['dr_type'], note_date=note['date']))
+    results.update(build_pdr_severity(curr['pdr'], note_date=note['date']))
     results.update(build_dr_tx(data['common']['treatment'], note_date=note['date']))
     results.update(build_edema(curr['binary_vars'], note_date=note['date']))
     results.update(build_sig_edema(curr['binary_vars'], note_date=note['date']))

--- a/test/amd/test_amd.py
+++ b/test/amd/test_amd.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eye_extractor.amd.amd import extract_amd
+from eye_extractor.amd.amd import AMD, extract_amd
 from eye_extractor.common.json import dumps_and_loads_json
 from eye_extractor.headers import Headers
 from eye_extractor.output.amd import build_amd
@@ -19,6 +19,9 @@ def test_amd(text, headers, amd_re, amd_le, amd_unk, note_date):
     pre_json = extract_amd(text, headers=Headers(headers))
     post_json = dumps_and_loads_json(pre_json)
     result = build_amd(post_json)
+    assert type(result['amd_re']) == int
+    assert type(result['amd_le']) == int
+    assert type(result['amd_unk']) == int
     assert result['amd_re'] == amd_re
     assert result['amd_le'] == amd_le
     assert result['amd_unk'] == amd_unk

--- a/test/common/test_macula_wnl.py
+++ b/test/common/test_macula_wnl.py
@@ -22,11 +22,16 @@ def test_macula_is_wnl(data, date, exp):
 
 @pytest.mark.parametrize('text, headers, amd_re, amd_le, amd_unk', [
     ('', {'MACULA': 'WNL OU'}, 0, 0, 0),
+    ('', {'MACULA': 'WNL OD'}, 0, -1, -1),
+    ('', {'MACULA': 'WNL OS'}, -1, 0, -1),
 ])
 def test_macula_wnl_on_amd(text, headers, amd_re, amd_le, amd_unk):
     pre_json = extract_macula_wnl(text, headers=Headers(headers))
     post_json = dumps_and_loads_json(pre_json)
     result = build_amd(None, macula_wnl=post_json)
+    assert type(result['amd_re']) == int
+    assert type(result['amd_le']) == int
+    assert type(result['amd_unk']) == int
     assert result['amd_re'] == amd_re
     assert result['amd_le'] == amd_le
     assert result['amd_unk'] == amd_unk

--- a/test/common/test_severity.py
+++ b/test/common/test_severity.py
@@ -12,6 +12,7 @@ from eye_extractor.common.severity import (
     SEVERE_PAT,
     Severity,
     SEVERITY_PAT,
+    VERY_SEVERE_PAT,
 )
 
 # Test pattern.
@@ -19,7 +20,7 @@ _pattern_cases = [
     (MILD_PAT, 'mild', True),
     (MODERATE_PAT, 'moderate', True),
     (SEVERE_PAT, 'severe', True),
-    (SEVERE_PAT, 'very severe', True),
+    (VERY_SEVERE_PAT, 'very severe', True),
     (SEVERITY_PAT, 'severity=1Q', True),
     (SEVERITY_PAT, 'severity=2Q', True),
     (SEVERITY_PAT, 'severity=3Q', True),
@@ -46,7 +47,7 @@ _dr_severity_extract_cases = [
     ('very mild', [Severity.MILD]),
     ('mild - moderate', [Severity.MODERATE, Severity.MILD]),
     ('moderate', [Severity.MODERATE]),
-    ('very severe', [Severity.SEVERE]),
+    ('very severe', [Severity.VERY_SEVERE]),
     ('heme severity=3Q', [Severity.Q3]),
     ('heme temporal and inferior quadrant', [Severity.Q2, Severity.Q1]),
     ('IRMA nasal quadrant', [Severity.Q1]),

--- a/test/common/test_severity.py
+++ b/test/common/test_severity.py
@@ -43,7 +43,7 @@ def test_severity_patterns(pat, text, exp):
 
 
 # Test extract and build.
-_dr_severity_extract_cases = [
+_severity_extract_cases = [
     ('very mild', [Severity.MILD]),
     ('mild - moderate', [Severity.MODERATE, Severity.MILD]),
     ('moderate', [Severity.MODERATE]),
@@ -56,7 +56,7 @@ _dr_severity_extract_cases = [
 
 
 @pytest.mark.parametrize('text, labels',
-                         _dr_severity_extract_cases)
+                         _severity_extract_cases)
 def test_extract_severity(text, labels):
     severities = extract_severity(text)
     for i, sev in enumerate(severities):

--- a/test/dr/test_cmt_value.py
+++ b/test/dr/test_cmt_value.py
@@ -1,22 +1,22 @@
 import json
 import pytest
 
-from eye_extractor.dr.cmt_value import CMT_VALUE_PAT, get_cmt_value
+from eye_extractor.dr.cmt_value import CMT_VALUE_OD_OS_UNK_PAT, get_cmt_value
 from eye_extractor.output.dr import build_cmt_value
 
 # Test pattern.
 _pattern_cases = [
-    (CMT_VALUE_PAT, 'CMT 244', True),
-    (CMT_VALUE_PAT, 'Central macular thickness: 234 um', True),
-    (CMT_VALUE_PAT, 'CMT OD: 265', True),
-    (CMT_VALUE_PAT, 'CMT OS 250', True),
-    (CMT_VALUE_PAT, 'CMT OD:265 OS:224', True),
-    (CMT_VALUE_PAT, 'Tonometry: TA OD:17 OS:17', False),
-    (CMT_VALUE_PAT, 'NCT: OD:11 OS:19', False),
-    (CMT_VALUE_PAT, 'Applanation Tonometry: 18 OD 12 OS', False),
-    (CMT_VALUE_PAT, 'OD: +125-240*103\nOS: +050-090*065\n', False),
-    (CMT_VALUE_PAT, 'TONOMETRY:\nTa OD: 14 OS 18', False),
-    (CMT_VALUE_PAT, 'OD CMT 123', True),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'CMT 244', True),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'Central macular thickness: 234 um', True),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'CMT OD: 265', True),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'CMT OS 250', True),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'CMT OD:265 OS:224', True),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'Tonometry: TA OD:17 OS:17', False),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'NCT: OD:11 OS:19', False),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'Applanation Tonometry: 18 OD 12 OS', False),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'OD: +125-240*103\nOS: +050-090*065\n', False),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'TONOMETRY:\nTa OD: 14 OS 18', False),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'OD CMT 123', True),
 
 ]
 
@@ -37,11 +37,11 @@ _cmt_value_extract_and_build_cases = [
     ('CMT OD:265 OS:224', {}, 265, 224, -1),
     ('CMT 343', {}, -1, -1, 343),
     ('Central macular thickness: 234 um', {}, -1, -1, 234),
+    ('CMT OD:300 possible epiretinal membrane OS:294', {}, 300, 294, -1),
     # ('OD: erm, CMT 291; OS: erm, CMT 280', {}, 291, 280, -1),
     # ('OD CMT 329; +ERM,  OS CMT 465; +ERM;', {}, 329, 465, -1),
     # ('OS: REMAINS DRY CMT 244', {}, -1, 244, -1),
-    # pytest.param('CMT OD:300 possible epiretinal membrane OS:294',
-    #              {}, 300, 294, -1, marks=pytest.mark.skip()),
+
     # ('OD: mild moderate irregularity, no edema, CMT 290; OS: moderate retinal irregularity , no edema, '
     #  'mild epiretinal membrane , CMT 282',
     #  {}, 290, 282, -1),

--- a/test/dr/test_cmt_value.py
+++ b/test/dr/test_cmt_value.py
@@ -1,7 +1,11 @@
 import json
 import pytest
 
-from eye_extractor.dr.cmt_value import CMT_VALUE_OD_OS_UNK_PAT, get_cmt_value
+from eye_extractor.dr.cmt_value import (
+    CMT_VALUE_OD_OS_UNK_PAT,
+    CMT_VALUE_OD_SEP_OS_PAT,
+    get_cmt_value,
+)
 from eye_extractor.output.dr import build_cmt_value
 
 # Test pattern.
@@ -11,13 +15,13 @@ _pattern_cases = [
     (CMT_VALUE_OD_OS_UNK_PAT, 'CMT OD: 265', True),
     (CMT_VALUE_OD_OS_UNK_PAT, 'CMT OS 250', True),
     (CMT_VALUE_OD_OS_UNK_PAT, 'CMT OD:265 OS:224', True),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'OD CMT 123', True),
     (CMT_VALUE_OD_OS_UNK_PAT, 'Tonometry: TA OD:17 OS:17', False),
     (CMT_VALUE_OD_OS_UNK_PAT, 'NCT: OD:11 OS:19', False),
     (CMT_VALUE_OD_OS_UNK_PAT, 'Applanation Tonometry: 18 OD 12 OS', False),
     (CMT_VALUE_OD_OS_UNK_PAT, 'OD: +125-240*103\nOS: +050-090*065\n', False),
-    (CMT_VALUE_OD_OS_UNK_PAT, 'TONOMETRY:\nTa OD: 14 OS 18', False),
-    (CMT_VALUE_OD_OS_UNK_PAT, 'OD CMT 123', True),
-
+    (CMT_VALUE_OD_OS_UNK_PAT, 'TONOMETRY:\nTa OD: 14 OS: 18', False),
+    (CMT_VALUE_OD_SEP_OS_PAT, 'CMT OD:300 possible epiretinal membrane OS:294', True),
 ]
 
 
@@ -38,13 +42,13 @@ _cmt_value_extract_and_build_cases = [
     ('CMT 343', {}, -1, -1, 343),
     ('Central macular thickness: 234 um', {}, -1, -1, 234),
     ('CMT OD:300 possible epiretinal membrane OS:294', {}, 300, 294, -1),
-    # ('OD: erm, CMT 291; OS: erm, CMT 280', {}, 291, 280, -1),
-    # ('OD CMT 329; +ERM,  OS CMT 465; +ERM;', {}, 329, 465, -1),
-    # ('OS: REMAINS DRY CMT 244', {}, -1, 244, -1),
-
-    # ('OD: mild moderate irregularity, no edema, CMT 290; OS: moderate retinal irregularity , no edema, '
-    #  'mild epiretinal membrane , CMT 282',
-    #  {}, 290, 282, -1),
+    ('OD CMT 123', {}, 123, -1, -1),
+    ('OD: erm, CMT 291; OS: erm, CMT 280', {}, 291, 280, -1),
+    ('OD CMT 329; +ERM,  OS CMT 465; +ERM;', {}, 329, 465, -1),
+    ('OS: REMAINS DRY CMT 244', {}, -1, 244, -1),
+    ('OD: mild moderate irregularity, no edema, CMT 290; OS: moderate retinal irregularity , no edema, '
+     'mild epiretinal membrane , CMT 282',
+     {}, 290, 282, -1),
     ('Acuities (cc) glare OD 20/30', {}, -1, -1, -1),
     ('OD 4/12', {}, -1, -1, -1),
     ('C/D: 0.6 OD 0.8 OS', {}, -1, -1, -1),
@@ -58,8 +62,6 @@ _cmt_value_extract_and_build_cases = [
     ('OD ¶1/2013:', {}, -1, -1, -1),
     ('¶2) Hem PVD OD ¶3)', {}, -1, -1, -1),
     ('OD12345678', {}, -1, -1, -1),
-    # ('OD CMT 123', {}, 123, -1, -1),
-
 ]
 
 

--- a/test/dr/test_cmt_value.py
+++ b/test/dr/test_cmt_value.py
@@ -16,6 +16,7 @@ _pattern_cases = [
     (CMT_VALUE_OD_OS_UNK_PAT, 'CMT OS 250', True),
     (CMT_VALUE_OD_OS_UNK_PAT, 'CMT OD:265 OS:224', True),
     (CMT_VALUE_OD_OS_UNK_PAT, 'OD CMT 123', True),
+    (CMT_VALUE_OD_OS_UNK_PAT, 'OD: erm, CMT 291; OS: erm, CMT 280', True),
     (CMT_VALUE_OD_OS_UNK_PAT, 'Tonometry: TA OD:17 OS:17', False),
     (CMT_VALUE_OD_OS_UNK_PAT, 'NCT: OD:11 OS:19', False),
     (CMT_VALUE_OD_OS_UNK_PAT, 'Applanation Tonometry: 18 OD 12 OS', False),
@@ -49,6 +50,8 @@ _cmt_value_extract_and_build_cases = [
     ('OD: mild moderate irregularity, no edema, CMT 290; OS: moderate retinal irregularity , no edema, '
      'mild epiretinal membrane , CMT 282',
      {}, 290, 282, -1),
+    ('CMT OS 250', {}, -1, 250, -1),
+    ('OD CMT 252, irregular RPE layer OU\nOS:CMT 210', {}, 252, 210, -1),
     ('Acuities (cc) glare OD 20/30', {}, -1, -1, -1),
     ('OD 4/12', {}, -1, -1, -1),
     ('C/D: 0.6 OD 0.8 OS', {}, -1, -1, -1),
@@ -62,6 +65,15 @@ _cmt_value_extract_and_build_cases = [
     ('OD ¶1/2013:', {}, -1, -1, -1),
     ('¶2) Hem PVD OD ¶3)', {}, -1, -1, -1),
     ('OD12345678', {}, -1, -1, -1),
+    ('Tonometry: TA OD:17 OS:17', {}, -1, -1, -1),
+    ('NCT: OD:11 OS:19', {}, -1, -1, -1),
+    ('Applanation Tonometry: 18 OD 12 OS', {}, -1, -1, -1),
+    ('OD: +125-240*103\nOS: +050-090X065\n', {}, -1, -1, -1),
+    ('TONOMETRY:\nTa OD: 14 OS: 18', {}, -1, -1, -1),
+    ('os:-.45-1.25x60', {}, -1, -1, -1),
+    ('IOP by applanation OD 10 OS 17\n', {}, -1, -1, -1),
+    ('low OS @ 19,17. OD @ 20 mm last 4 exams', {}, -1, -1, -1),
+    ('»»Average thickness: OD: 21» OS: 89', {}, -1, -1, -1),
 ]
 
 
@@ -73,7 +85,7 @@ def test_cmt_value_extract_and_build(text,
                                      exp_dmacedema_cmt_le,
                                      exp_dmacedema_cmt_unk):
     pre_json = get_cmt_value(text)
-    post_json = json.loads(json.dumps(pre_json))
+    post_json = json.loads(json.dumps(pre_json, default=str))
     result = build_cmt_value(post_json)
     assert result['dmacedema_cmt_re'] == exp_dmacedema_cmt_re
     assert result['dmacedema_cmt_le'] == exp_dmacedema_cmt_le

--- a/test/dr/test_cmt_value.py
+++ b/test/dr/test_cmt_value.py
@@ -9,7 +9,15 @@ _pattern_cases = [
     (CMT_VALUE_PAT, 'CMT 244', True),
     (CMT_VALUE_PAT, 'Central macular thickness: 234 um', True),
     (CMT_VALUE_PAT, 'CMT OD: 265', True),
-    (CMT_VALUE_PAT, 'OS:300', True),
+    (CMT_VALUE_PAT, 'CMT OS 250', True),
+    (CMT_VALUE_PAT, 'CMT OD:265 OS:224', True),
+    (CMT_VALUE_PAT, 'Tonometry: TA OD:17 OS:17', False),
+    (CMT_VALUE_PAT, 'NCT: OD:11 OS:19', False),
+    (CMT_VALUE_PAT, 'Applanation Tonometry: 18 OD 12 OS', False),
+    (CMT_VALUE_PAT, 'OD: +125-240*103\nOS: +050-090*065\n', False),
+    (CMT_VALUE_PAT, 'TONOMETRY:\nTa OD: 14 OS 18', False),
+    (CMT_VALUE_PAT, 'OD CMT 123', True),
+
 ]
 
 
@@ -25,17 +33,18 @@ def test_cmt_value_patterns(pat, text, exp):
 
 # Test extract and build.
 _cmt_value_extract_and_build_cases = [
-    ('OD: erm, CMT 291; OS: erm, CMT 280', {}, 291, 280, -1),
-    ('OD CMT 329; +ERM,  OS CMT 465; +ERM;', {}, 329, 465, -1),
     ('CMT OD: 219', {}, 219, -1, -1),
     ('CMT OD:265 OS:224', {}, 265, 224, -1),
-    ('OS: REMAINS DRY CMT 244', {}, -1, 244, -1),
-    pytest.param('CMT OD:300 possible epiretinal membrane OS:294 mild epiretinal membrane',
-                 {}, 300, 294, -1, marks=pytest.mark.skip()),
-    ('OD: mild moderate irregularity, no edema, CMT 290; OS: moderate retinal irregularity , no edema, '
-     'mild epiretinal membrane , CMT 282',
-     {}, 290, 282, -1),
+    ('CMT 343', {}, -1, -1, 343),
     ('Central macular thickness: 234 um', {}, -1, -1, 234),
+    # ('OD: erm, CMT 291; OS: erm, CMT 280', {}, 291, 280, -1),
+    # ('OD CMT 329; +ERM,  OS CMT 465; +ERM;', {}, 329, 465, -1),
+    # ('OS: REMAINS DRY CMT 244', {}, -1, 244, -1),
+    # pytest.param('CMT OD:300 possible epiretinal membrane OS:294',
+    #              {}, 300, 294, -1, marks=pytest.mark.skip()),
+    # ('OD: mild moderate irregularity, no edema, CMT 290; OS: moderate retinal irregularity , no edema, '
+    #  'mild epiretinal membrane , CMT 282',
+    #  {}, 290, 282, -1),
     ('Acuities (cc) glare OD 20/30', {}, -1, -1, -1),
     ('OD 4/12', {}, -1, -1, -1),
     ('C/D: 0.6 OD 0.8 OS', {}, -1, -1, -1),
@@ -49,6 +58,8 @@ _cmt_value_extract_and_build_cases = [
     ('OD ¶1/2013:', {}, -1, -1, -1),
     ('¶2) Hem PVD OD ¶3)', {}, -1, -1, -1),
     ('OD12345678', {}, -1, -1, -1),
+    # ('OD CMT 123', {}, 123, -1, -1),
+
 ]
 
 

--- a/test/dr/test_dr_type.py
+++ b/test/dr/test_dr_type.py
@@ -5,8 +5,9 @@ from eye_extractor.common.severity import Severity
 from eye_extractor.dr.dr_type import (
     DrType,
     get_dr_type,
+    get_pdr,
     NPDR_PAT,
-    PDR_PAT
+    PDR_PAT,
 )
 from eye_extractor.output.dr import build_dr_type, build_npdr_severity, build_pdr_severity
 
@@ -38,9 +39,9 @@ def test_dr_type_patterns(pat, text, exp):
 
 # Test extract and build.
 _dr_type_extract_and_build_cases = [
-    ('Type II DM with mild - moderate NPDR ou', {}, DrType.NPDR, DrType.NPDR, DrType.UNKNOWN),
-    ('DM w/out NPDR OU', {}, DrType.NONE, DrType.NONE, DrType.UNKNOWN),
-    ('no NPDR', {}, DrType.UNKNOWN, DrType.UNKNOWN, DrType.NONE),
+    # ('Type II DM with mild - moderate NPDR ou', {}, DrType.NPDR, DrType.NPDR, DrType.UNKNOWN),
+    # ('DM w/out NPDR OU', {}, DrType.NONE, DrType.NONE, DrType.UNKNOWN),
+    # ('no NPDR', {}, DrType.UNKNOWN, DrType.UNKNOWN, DrType.NONE),
     ('MODERATE NONPROLIFERATIVE DIABETIC RETINOPATHY OD', {}, DrType.NPDR, DrType.UNKNOWN, DrType.UNKNOWN),
     ('proliferative Diabetic Retinopathy: YES, MILD OU', {}, DrType.PDR, DrType.PDR, DrType.UNKNOWN),
     ('Proliferative diabetic retinopathy OS', {}, DrType.UNKNOWN, DrType.PDR, DrType.UNKNOWN),
@@ -61,24 +62,6 @@ _dr_type_extract_and_build_cases = [
     # ('Background diabetic retinopathy ¶ ¶ ¶Plan.) start alphagan ou', {}, DrType.UNKNOWN, DrType.UNKNOWN, DrType.NPDR),
 ]
 
-_npdr_severity_extract_and_build_cases = [
-    ('mild BDR OU', {}, 'MILD', 'MILD', 'UNKNOWN'),
-    ('Mild - moderate non-proliferative DR OD', {}, 'MODERATE', 'UNKNOWN', 'UNKNOWN'),
-    ('no NPDR ou', {}, 'NONE', 'NONE', 'UNKNOWN'),
-    ('moderate background diabetic retinopathy OS', {}, 'UNKNOWN', 'MODERATE', 'UNKNOWN'),
-    ('severe NPDR', {}, 'UNKNOWN', 'UNKNOWN', 'SEVERE'),
-    ('very severe NPDR ou', {}, 'VERY SEVERE', 'VERY SEVERE', 'UNKNOWN'),
-    ('NPDR OS', {}, 'UNKNOWN', 'YES NOS', 'UNKNOWN'),
-]
-
-_pdr_severity_extract_and_build_cases = [
-    ('mild PDR OU', {}, 'MILD', 'MILD', 'UNKNOWN'),
-    ('Mild - moderate proliferative DR OD', {}, 'MODERATE', 'UNKNOWN', 'UNKNOWN'),
-    ('no PDR ou', {}, 'NONE', 'NONE', 'UNKNOWN'),
-    ('moderate proliferative diabetic retinopathy OS', {}, 'UNKNOWN', 'MODERATE', 'UNKNOWN'),
-    ('severe proliferative DR', {}, 'UNKNOWN', 'UNKNOWN', 'SEVERE')
-]
-
 
 @pytest.mark.parametrize('text, headers, exp_diabretinop_type_re, exp_diabretinop_type_le, '
                          'exp_diabretinop_type_unk',
@@ -94,6 +77,18 @@ def test_dr_type_extract_and_build(text,
     assert result['diabretinop_type_re'] == exp_diabretinop_type_re
     assert result['diabretinop_type_le'] == exp_diabretinop_type_le
     assert result['diabretinop_type_unk'] == exp_diabretinop_type_unk
+
+
+_npdr_severity_extract_and_build_cases = [
+    ('mild BDR OU', {}, 'MILD', 'MILD', 'UNKNOWN'),
+    ('Mild - moderate non-proliferative DR OD', {}, 'MODERATE', 'UNKNOWN', 'UNKNOWN'),
+    ('no NPDR ou', {}, 'NONE', 'NONE', 'UNKNOWN'),
+    ('moderate background diabetic retinopathy OS', {}, 'UNKNOWN', 'MODERATE', 'UNKNOWN'),
+    ('severe NPDR', {}, 'UNKNOWN', 'UNKNOWN', 'SEVERE'),
+    ('very severe NPDR ou', {}, 'VERY SEVERE', 'VERY SEVERE', 'UNKNOWN'),
+    ('NPDR OS', {}, 'UNKNOWN', 'YES NOS', 'UNKNOWN'),
+    ('PDR OU', {}, 'UNKNOWN', 'UNKNOWN', 'UNKNOWN'),
+]
 
 
 @pytest.mark.parametrize('text, headers, exp_nonprolifdr_re, exp_nonprolifdr_le, '
@@ -112,6 +107,21 @@ def test_npdr_severity_extract_and_build(text,
     assert result['nonprolifdr_unk'] == exp_nonprolifdr_unk
 
 
+_pdr_severity_extract_and_build_cases = [
+    ('PDR OU', {}, 'YES NOS', 'YES NOS', 'UNKNOWN'),
+    ('Mild - moderate proliferative DR OD', {}, 'YES NOS', 'UNKNOWN', 'UNKNOWN'),
+    ('no PDR ou', {}, 'NONE', 'NONE', 'UNKNOWN'),
+    ('moderate proliferative diabetic retinopathy OS', {}, 'UNKNOWN', 'YES NOS', 'UNKNOWN'),
+    ('proliferative DR', {}, 'UNKNOWN', 'UNKNOWN', 'YES NOS'),
+    ('PRP OU for PDR', {}, 'YES NOS', 'YES NOS', 'UNKNOWN'),
+    ('New PDR os', {}, 'UNKNOWN', 'YES NOS', 'UNKNOWN'),
+    ('Stable proliferative diabetic retinopathy of both eyes', {}, 'YES NOS', 'YES NOS', 'UNKNOWN'),
+    ('Proliferative diabetic retinopathy of right eye', {}, 'YES NOS', 'UNKNOWN', 'UNKNOWN'),
+    ('Low risk proliferative diabetic retinopathy OU', {}, 'LOW RISK', 'LOW RISK', 'UNKNOWN'),  # Synthetic.
+    ('High risk PDR OS', {}, 'UNKNOWN', 'HIGH RISK', 'UNKNOWN'),  # Synthetic.
+]
+
+
 @pytest.mark.parametrize('text, headers, exp_prolifdr_re, exp_prolifdr_le, '
                          'exp_prolifdr_unk',
                          _pdr_severity_extract_and_build_cases)
@@ -120,7 +130,7 @@ def test_pdr_severity_extract_and_build(text,
                                         exp_prolifdr_re,
                                         exp_prolifdr_le,
                                         exp_prolifdr_unk):
-    pre_json = get_dr_type(text)
+    pre_json = get_pdr(text)
     post_json = json.loads(json.dumps(pre_json))
     result = build_pdr_severity(post_json)
     assert result['prolifdr_re'] == exp_prolifdr_re

--- a/test/dr/test_dr_type.py
+++ b/test/dr/test_dr_type.py
@@ -54,6 +54,7 @@ _dr_type_extract_and_build_cases = [
     ('¶(1) No diabetic retinopathy.', {},
      DrType.UNKNOWN, DrType.UNKNOWN, DrType.NONE),
     ('NPDR : no ', {}, DrType.UNKNOWN, DrType.UNKNOWN, DrType.NONE),
+    ('very severe NPDR ou', {}, DrType.NPDR, DrType.NPDR, DrType.UNKNOWN),
     # TODO: Resolve laterality issues to pass below tests.
     # ('nonproliferative diabetic retinopathy ¶ iols ou', {}, DrType.UNKNOWN, DrType.UNKNOWN, DrType.NPDR),
     # ('¶(1) No diabetic retinopathy. ¶(2) Increasing cataract, RE,', {}, DrType.UNKNOWN, DrType.UNKNOWN, DrType.NONE),
@@ -65,7 +66,8 @@ _npdr_severity_extract_and_build_cases = [
     ('Mild - moderate non-proliferative DR OD', {}, 'MODERATE', 'UNKNOWN', 'UNKNOWN'),
     ('no NPDR ou', {}, 'NONE', 'NONE', 'UNKNOWN'),
     ('moderate background diabetic retinopathy OS', {}, 'UNKNOWN', 'MODERATE', 'UNKNOWN'),
-    ('severe NPDR', {}, 'UNKNOWN', 'UNKNOWN', 'SEVERE')
+    ('severe NPDR', {}, 'UNKNOWN', 'UNKNOWN', 'SEVERE'),
+    ('very severe NPDR ou', {}, 'VERY SEVERE', 'VERY SEVERE', 'UNKNOWN'),
 ]
 
 _pdr_severity_extract_and_build_cases = [

--- a/test/dr/test_dr_type.py
+++ b/test/dr/test_dr_type.py
@@ -68,7 +68,7 @@ _npdr_severity_extract_and_build_cases = [
     ('moderate background diabetic retinopathy OS', {}, 'UNKNOWN', 'MODERATE', 'UNKNOWN'),
     ('severe NPDR', {}, 'UNKNOWN', 'UNKNOWN', 'SEVERE'),
     ('very severe NPDR ou', {}, 'VERY SEVERE', 'VERY SEVERE', 'UNKNOWN'),
-    ('NPDR OS', {}, 'UNKNOWN', 'NOS', 'UNKNOWN'),
+    ('NPDR OS', {}, 'UNKNOWN', 'YES NOS', 'UNKNOWN'),
 ]
 
 _pdr_severity_extract_and_build_cases = [

--- a/test/dr/test_dr_type.py
+++ b/test/dr/test_dr_type.py
@@ -68,6 +68,7 @@ _npdr_severity_extract_and_build_cases = [
     ('moderate background diabetic retinopathy OS', {}, 'UNKNOWN', 'MODERATE', 'UNKNOWN'),
     ('severe NPDR', {}, 'UNKNOWN', 'UNKNOWN', 'SEVERE'),
     ('very severe NPDR ou', {}, 'VERY SEVERE', 'VERY SEVERE', 'UNKNOWN'),
+    ('NPDR OS', {}, 'UNKNOWN', 'NOS', 'UNKNOWN'),
 ]
 
 _pdr_severity_extract_and_build_cases = [

--- a/test/dr/test_dr_type.py
+++ b/test/dr/test_dr_type.py
@@ -39,9 +39,9 @@ def test_dr_type_patterns(pat, text, exp):
 
 # Test extract and build.
 _dr_type_extract_and_build_cases = [
-    # ('Type II DM with mild - moderate NPDR ou', {}, DrType.NPDR, DrType.NPDR, DrType.UNKNOWN),
-    # ('DM w/out NPDR OU', {}, DrType.NONE, DrType.NONE, DrType.UNKNOWN),
-    # ('no NPDR', {}, DrType.UNKNOWN, DrType.UNKNOWN, DrType.NONE),
+    ('Type II DM with mild - moderate NPDR ou', {}, DrType.NPDR, DrType.NPDR, DrType.UNKNOWN),
+    ('DM w/out NPDR OU', {}, DrType.NONE, DrType.NONE, DrType.UNKNOWN),
+    ('no NPDR', {}, DrType.UNKNOWN, DrType.UNKNOWN, DrType.NONE),
     ('MODERATE NONPROLIFERATIVE DIABETIC RETINOPATHY OD', {}, DrType.NPDR, DrType.UNKNOWN, DrType.UNKNOWN),
     ('proliferative Diabetic Retinopathy: YES, MILD OU', {}, DrType.PDR, DrType.PDR, DrType.UNKNOWN),
     ('Proliferative diabetic retinopathy OS', {}, DrType.UNKNOWN, DrType.PDR, DrType.UNKNOWN),

--- a/test/dr/test_hemorrhage_type.py
+++ b/test/dr/test_hemorrhage_type.py
@@ -139,7 +139,7 @@ _intraretinal_severity_extract_and_build_cases = [
     ('intraretinal hemorrhage temporal and inferior quadrant OD', {}, 'Q2', 'UNKNOWN', 'UNKNOWN'),
     ('nasal quadrant, hemorrhage intraretinal', {}, 'UNKNOWN', 'UNKNOWN', 'Q1'),
     ('intraretinal heme in all quadrants ou', {}, 'Q4', 'Q4', 'UNKNOWN'),
-    ('swelling and intraretinal hemorrhage', {}, 'UNKNOWN', 'UNKNOWN', 'NOS'),
+    ('swelling and intraretinal hemorrhage', {}, 'UNKNOWN', 'UNKNOWN', 'YES NOS'),
 ]
 
 
@@ -169,7 +169,7 @@ _dot_blot_severity_extract_and_build_cases = [
     ('dot blot hemorrhage temporal and inferior quadrant OD', {}, 'Q2', 'UNKNOWN', 'UNKNOWN'),
     ('dot blot heme in all quadrants ou', {}, 'Q4', 'Q4', 'UNKNOWN'),
     ('*scattered d/b hemes in all 4 quadrants (-)CWS', {}, 'UNKNOWN', 'UNKNOWN', 'Q4'),
-    ('occasional dot/blot heme', {}, 'UNKNOWN', 'UNKNOWN', 'NOS'),
+    ('occasional dot/blot heme', {}, 'UNKNOWN', 'UNKNOWN', 'YES NOS'),
 ]
 
 

--- a/test/dr/test_hemorrhage_type.py
+++ b/test/dr/test_hemorrhage_type.py
@@ -15,7 +15,7 @@ from eye_extractor.output.dr import build_dot_blot_severity, build_hemorrhage_ty
 ])
 def test_get_hemorrhage_type(text, exp_value, exp_negword):
     data = get_hemorrhage_type(text)
-    variable = list(data[0].values())[0]
+    variable = list(data[-1].values())[0]  # 'hemorrhage_typ_dr' will be last variable added to `data`.
 
     assert len(data) > 0
     assert variable['value'] == exp_value
@@ -139,6 +139,7 @@ _intraretinal_severity_extract_and_build_cases = [
     ('intraretinal hemorrhage temporal and inferior quadrant OD', {}, 'Q2', 'UNKNOWN', 'UNKNOWN'),
     ('nasal quadrant, hemorrhage intraretinal', {}, 'UNKNOWN', 'UNKNOWN', 'Q1'),
     ('intraretinal heme in all quadrants ou', {}, 'Q4', 'Q4', 'UNKNOWN'),
+    ('swelling and intraretinal hemorrhage', {}, 'UNKNOWN', 'UNKNOWN', 'NOS'),
 ]
 
 
@@ -168,6 +169,7 @@ _dot_blot_severity_extract_and_build_cases = [
     ('dot blot hemorrhage temporal and inferior quadrant OD', {}, 'Q2', 'UNKNOWN', 'UNKNOWN'),
     ('dot blot heme in all quadrants ou', {}, 'Q4', 'Q4', 'UNKNOWN'),
     ('*scattered d/b hemes in all 4 quadrants (-)CWS', {}, 'UNKNOWN', 'UNKNOWN', 'Q4'),
+    ('occasional dot/blot heme', {}, 'UNKNOWN', 'UNKNOWN', 'NOS'),
 ]
 
 

--- a/test/dr/test_irma.py
+++ b/test/dr/test_irma.py
@@ -24,7 +24,7 @@ def test_irma_patterns(pat, text, exp):
 
 # Test extract and build.
 _irma_extract_and_build_cases = [
-    ('OD: area of IRMA just nasal to disc', {}, 'MILD', 'UNKNOWN', 'UNKNOWN'),
+    ('OD: area of IRMA just nasal to disc', {}, 'NOS', 'UNKNOWN', 'UNKNOWN'),
     ('mild IRMA OU', {}, 'MILD', 'MILD', 'UNKNOWN'),
     ('Mild - moderate IRMA OD', {}, 'MODERATE', 'UNKNOWN', 'UNKNOWN'),
     ('no intraretinal microvascular abnormality ou', {}, 'NONE', 'NONE', 'UNKNOWN'),
@@ -34,7 +34,7 @@ _irma_extract_and_build_cases = [
     ('IRMA temporal and inferior quadrant OD', {}, 'Q2', 'UNKNOWN', 'UNKNOWN'),
     ('nasal quadrant, IRMA', {}, 'UNKNOWN', 'UNKNOWN', 'Q1'),
     ('IRMA in all quadrants ou', {}, 'Q4', 'Q4', 'UNKNOWN'),
-    ('has small area of IRMA right eye', {}, 'MILD', 'UNKNOWN', 'UNKNOWN'),
+    ('has small area of IRMA right eye', {}, 'NOS', 'UNKNOWN', 'UNKNOWN'),
     ('(-)heme, MA, HE, CWS, VB, IRMA, NVE OU', {}, 'NONE', 'NONE', 'UNKNOWN'),
     ('¶Irma Smith CSN:', {}, 'UNKNOWN', 'UNKNOWN', 'UNKNOWN'),
     ('OU: No Microaneurysms/hemes, cotton-wool spots, exudates, IRMA',

--- a/test/dr/test_irma.py
+++ b/test/dr/test_irma.py
@@ -24,7 +24,7 @@ def test_irma_patterns(pat, text, exp):
 
 # Test extract and build.
 _irma_extract_and_build_cases = [
-    ('OD: area of IRMA just nasal to disc', {}, 'NOS', 'UNKNOWN', 'UNKNOWN'),
+    ('OD: area of IRMA just nasal to disc', {}, 'YES NOS', 'UNKNOWN', 'UNKNOWN'),
     ('mild IRMA OU', {}, 'MILD', 'MILD', 'UNKNOWN'),
     ('Mild - moderate IRMA OD', {}, 'MODERATE', 'UNKNOWN', 'UNKNOWN'),
     ('no intraretinal microvascular abnormality ou', {}, 'NONE', 'NONE', 'UNKNOWN'),
@@ -34,7 +34,7 @@ _irma_extract_and_build_cases = [
     ('IRMA temporal and inferior quadrant OD', {}, 'Q2', 'UNKNOWN', 'UNKNOWN'),
     ('nasal quadrant, IRMA', {}, 'UNKNOWN', 'UNKNOWN', 'Q1'),
     ('IRMA in all quadrants ou', {}, 'Q4', 'Q4', 'UNKNOWN'),
-    ('has small area of IRMA right eye', {}, 'NOS', 'UNKNOWN', 'UNKNOWN'),
+    ('has small area of IRMA right eye', {}, 'YES NOS', 'UNKNOWN', 'UNKNOWN'),
     ('(-)heme, MA, HE, CWS, VB, IRMA, NVE OU', {}, 'NONE', 'NONE', 'UNKNOWN'),
     ('¶Irma Smith CSN:', {}, 'UNKNOWN', 'UNKNOWN', 'UNKNOWN'),
     ('OU: No Microaneurysms/hemes, cotton-wool spots, exudates, IRMA',

--- a/test/dr/test_venous_beading.py
+++ b/test/dr/test_venous_beading.py
@@ -25,7 +25,7 @@ def test_ven_beading_patterns(pat, text, exp):
 
 # Test extract and build.
 _ven_beading_extract_and_build_cases = [
-    ('venous beading ou', {}, 'MILD', 'MILD', 'UNKNOWN'),
+    ('venous beading ou', {}, 'NOS', 'NOS', 'UNKNOWN'),
     ('mild VB OU', {}, 'MILD', 'MILD', 'UNKNOWN'),
     ('Mild - moderate venous beading OD', {}, 'MODERATE', 'UNKNOWN', 'UNKNOWN'),
     ('no venous beading ou', {}, 'NONE', 'NONE', 'UNKNOWN'),
@@ -54,12 +54,12 @@ _ven_beading_extract_and_build_cases = [
          'Vessels': 'good caliber and crossings; no venous beading; no plaques or emboli'
      },
      'UNKNOWN', 'UNKNOWN', 'NONE'),
-    ('Vessels: good caliber, color, and crossings OU, no plaques or emboli OU (-) MAs, Venous Beading, IRMA, CWS',
-     {}, 'NONE', 'NONE', 'UNKNOWN'),
     # Unless specified, all conditions in negated list are OU.
     # Since no laterality specified, laterality should be OU.
     ('no CWS, MA, IRMA, VB', {}, 'NONE', 'NONE', 'UNKNOWN'),
     ('(-) MAs, Venous Beading, IRMA, CWS', {}, 'NONE', 'NONE', 'UNKNOWN'),
+    ('Vessels: good caliber, color, and crossings OU, no plaques or emboli OU (-) MAs, Venous Beading, IRMA, CWS',
+     {}, 'NONE', 'NONE', 'UNKNOWN'),
     ('Macula: flat, dry (-)heme, MA, HE, CWS, VB, IRMA, NVE OD, ERM OS', {}, 'NONE', 'NONE', 'UNKNOWN'),
     ('Macula: flat, dry (-)heme, MA, HE, CWS, VB, IRMA, NVE OD, ERM OS',
      {

--- a/test/dr/test_venous_beading.py
+++ b/test/dr/test_venous_beading.py
@@ -25,7 +25,7 @@ def test_ven_beading_patterns(pat, text, exp):
 
 # Test extract and build.
 _ven_beading_extract_and_build_cases = [
-    ('venous beading ou', {}, 'NOS', 'NOS', 'UNKNOWN'),
+    ('venous beading ou', {}, 'YES NOS', 'YES NOS', 'UNKNOWN'),
     ('mild VB OU', {}, 'MILD', 'MILD', 'UNKNOWN'),
     ('Mild - moderate venous beading OD', {}, 'MODERATE', 'UNKNOWN', 'UNKNOWN'),
     ('no venous beading ou', {}, 'NONE', 'NONE', 'UNKNOWN'),


### PR DESCRIPTION
Second and third pass for diabetic retinopathy variables after abstractor review. The following changes have been made:

1. Second pass refinement for `dmacedema_cmt`. Complete pattern overhaul.
2. Severity variable changes:
    - 'VERY SEVERE' option added.
    - 'YES NOS' option added when severity is not captured.
    - Applies to: 
        - `venbeading`
        - `irma`
        - `nonprolifdr`
        - `intraretinal_hem`
        - `dotblot_hem`
3. `amd` output fix. Ensures ints, not `AMD` IntEnum are output.
4. Created and implemented `Risk` Enum for `prolifdr`.